### PR TITLE
chore(dbt): Remove startup.sh from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dags/**/*.pyc
 /logs
 /db-data
 .DS_Store
+
+/startup_script/startup.sh

--- a/startup_script/startup.sh.sample
+++ b/startup_script/startup.sh.sample
@@ -34,6 +34,8 @@ python3.11 -m pip install dbt-core==1.8.0b1 dbt-redshift==1.8.0b1
 dbt --version
 deactivate
 
+echo "export DBT_PROFILE_TARGET='dev'" >> /usr/local/airflow/envs/.virtualenv-dbt/bin/activate
+
 echo "Deactivate DBT Virtual Environment"
 pyenv shell system
 pyenv global system


### PR DESCRIPTION
Removes startup.sh from git since each dev would have different configurations per project and their respective IAM details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `.gitignore` file to exclude specific startup scripts.
- **New Features**
	- Enhanced the startup script sample to automatically set the `DBT_PROFILE_TARGET` environment variable to 'dev'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->