### PR TITLE
fix(bootstrap.sh): bump the mariadb version from 11.1 to 11.2

### DIFF
--- a/docker/script/bootstrap.sh
+++ b/docker/script/bootstrap.sh
@@ -53,13 +53,13 @@ sudo mkdir mariadb_rpm
 sudo chown airflow /mariadb_rpm
 
 if [[ $(uname -p) == "aarch64" ]]; then
-  wget https://mirror.mariadb.org/yum/11.1/fedora38-aarch64/rpms/MariaDB-common-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
-  wget https://mirror.mariadb.org/yum/11.1/fedora38-aarch64/rpms/MariaDB-shared-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
-  wget https://mirror.mariadb.org/yum/11.1/fedora38-aarch64/rpms/MariaDB-devel-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+  wget https://mirror.mariadb.org/yum/11.2/fedora38-aarch64/rpms/MariaDB-common-11.2.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+  wget https://mirror.mariadb.org/yum/11.2/fedora38-aarch64/rpms/MariaDB-shared-11.2.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+  wget https://mirror.mariadb.org/yum/11.2/fedora38-aarch64/rpms/MariaDB-devel-11.2.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
 else
-  wget https://mirror.mariadb.org/yum/11.1/fedora38-amd64/rpms/MariaDB-common-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
-  wget https://mirror.mariadb.org/yum/11.1/fedora38-amd64/rpms/MariaDB-shared-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
-  wget https://mirror.mariadb.org/yum/11.1/fedora38-amd64/rpms/MariaDB-devel-11.1.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+  wget https://mirror.mariadb.org/yum/11.2/fedora38-amd64/rpms/MariaDB-common-11.2.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+  wget https://mirror.mariadb.org/yum/11.2/fedora38-amd64/rpms/MariaDB-shared-11.2.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
+  wget https://mirror.mariadb.org/yum/11.2/fedora38-amd64/rpms/MariaDB-devel-11.2.2-1.fc38.$(uname -p).rpm -P /mariadb_rpm
 fi
 
 # install mariadb_devel and its dependencies


### PR DESCRIPTION
version `11.1` no longer exists on the mirror server we're using, which causes the `bootstrap.sh` script to fail (on the 404), which causes the `./mwaa-local-env start` command to fail. This can be resolved by using version `11.2` instead.

I chose 11.2 because it was the next minor version available and worked for me locally, but it may make sense to use the most recent minor version (11.7) instead -- I just haven't tested that yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the installation process for MariaDB to version 11.2.2.
	- Added installation steps for `dnf-plugins-core` and building dependencies for Python 3.
	- Continued support for Python 3.11 and maintained the upgrade process for pip and necessary dependencies for Apache Airflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->