### PR TITLE
chore: add openpyxl for xlsx reading

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -14,6 +14,7 @@ boto3==1.33.13
 s3fs==2023.12.2
 pyarrow==14.0.2
 xlsxwriter
+openpyxl==3.1.5
 openai==1.7.2
 gspread==6.1.0
 oauth2client==4.1.3


### PR DESCRIPTION
Part of PEX-193

Needed because of https://github.com/AdAction/airflow-dags/pull/2080

---

- Adds `openpyxl==3.1.5` to MWAA requirements — needed by `pandas.read_excel()` to parse `.xlsx` files in the reviewed fraud report ingestor DAG (`reviewed_fraud_report_ingestor`)

## Test plan

- [ ] Merge and redeploy MWAA environment (not sure if this needs to be triggered manually)
- [ ] Trigger `reviewed_fraud_report_ingestor` in production and confirm it parses the xlsx without the missing openpyxl error

🤖 Generated with [Claude Code](https://claude.com/claude-code)