### PR TITLE
revert: remove openpyxl added to wrong requirements file

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -14,7 +14,6 @@ boto3==1.33.13
 s3fs==2023.12.2
 pyarrow==14.0.2
 xlsxwriter
-openpyxl==3.1.5
 openai==1.7.2
 gspread==6.1.0
 oauth2client==4.1.3


### PR DESCRIPTION
Reverts AdAction/aws-mwaa-local-runner#18

---

- Removes `openpyxl==3.1.5` from `requirements/requirements.txt` — this is the local Docker runner requirements, not the production MWAA requirements
- `openpyxl` was added here by mistake; production MWAA dependencies live in the `aws-airflow` repo under `assets/requirements.txt`

## Test plan

- [ ] Verify `requirements/requirements.txt` no longer contains `openpyxl`
- [ ] Confirm production MWAA requirements are being updated via the `aws-airflow` repo PR instead